### PR TITLE
make chacha20Key.Open append plaintext to dst

### DIFF
--- a/chacha20poly1305.go
+++ b/chacha20poly1305.go
@@ -116,7 +116,7 @@ func (k *chacha20Key) Open(dst, nonce, ciphertext, data []byte) ([]byte, error) 
 	plaintext := make([]byte, len(ciphertext))
 	c.XORKeyStream(plaintext, ciphertext)
 
-	return plaintext, nil
+	return append(dst, plaintext...), nil
 }
 
 // Converts the given key and nonce into 64 bytes of ChaCha20 key stream, the


### PR DESCRIPTION
Open currently returns the plaintext slice and does not touch the dst slice. According to the docs of cipher.AEAD:

> "[I]f successful, appends the resulting plaintext to dst, returning the updated slice."

This PR adds the append call to Open and nothing else.
